### PR TITLE
Aggregate counts by data provider + message type groups

### DIFF
--- a/main.py
+++ b/main.py
@@ -46,15 +46,14 @@ def aggregate_results(local_test, context=None):
     received_message_ids = []
 
     error_dict = {}
+    result_dict = {}
     sqs_msgs_received = 0
-    files_analyzed = 0
-    records_analyzed = 0
-    validation_count = 0
-    validations_failed = 0
+    total_validation_count = 0
+    total_validations_failed = 0
 
     messages = sqs_extended.receive_message(
         queue_url=result_queue_url, max_number_Of_Messages=1)
-    error_details = []
+    error_details = {}
     while messages != None and len(messages) > 0 and context.get_remaining_time_in_millis() > 10000:
         sqs_msgs_received += 1
         logger.debug("Current message: %s" % messages[0]['MessageId'])
@@ -62,24 +61,43 @@ def aggregate_results(local_test, context=None):
             logger.debug(
                 "Detected previously processed SQS message, skipping to prevent duplicates...")
         else:
-            files_analyzed += 1
             received_message_ids.append(messages[0]['MessageId'])
             cur_msg_json = json.loads(messages[0]['Body'])
             cur_msg_key = cur_msg_json['key']
             logger.info("Analyzing file %s" % cur_msg_key)
-            error_dict[cur_msg_key] = []
+
+            data_provider, message_type = cur_msg_json['data_group'].split(':')
+            if not result_dict.get(data_provider):
+                result_dict[data_provider] = {}
+            if not result_dict[data_provider].get(message_type):
+                result_dict[data_provider][message_type] = {
+                    'files_analyzed': 0,
+                    'records_analyzed': 0,
+                    'validation_count': 0,
+                    'validations_failed': 0
+                }
+            errKey = data_provider+','+message_type
+            if not error_dict.get(errKey):
+                error_dict[errKey] = {}
+                error_details[errKey] = {}
+            error_dict[errKey][cur_msg_key] = []
+            error_details[errKey][cur_msg_key] = []
+
+            result_dict[data_provider][message_type]['files_analyzed'] += 1
+
             cur_msg_results = cur_msg_json['results']
             for result in cur_msg_results:
-                records_analyzed += 1
+                result_dict[data_provider][message_type]['records_analyzed'] += 1
                 for validation in result['Validations']:
-                    validation_count += 1
+                    result_dict[data_provider][message_type]['validation_count'] += 1
+                    total_validation_count += 1
                     if not validation['Valid']:
-                        validations_failed += 1
+                        result_dict[data_provider][message_type]['validations_failed'] += 1
+                        total_validations_failed += 1
                         logger.debug("Found failed validation: %s" %
                                      validation)
-                        error_dict[cur_msg_key].append(
-                            {"Error": validation['Details']})
-                        error_details.append(validation['Details'])
+                        error_dict[errKey][cur_msg_key].append(validation['Details'])
+                        error_details[errKey][cur_msg_key].append(validation['Details'])
 
         sqs_extended.delete_message(
             queue_url=result_queue_url, receipt_handle=messages[0]['ReceiptHandle'])
@@ -89,15 +107,12 @@ def aggregate_results(local_test, context=None):
     logger.debug(
         "Finished message polling loop, found %d SQS messages." % sqs_msgs_received)
     logger.debug("Error dict: %s" % json.dumps(error_dict))
-
+    logger.debug("Error details: %s" % json.dumps(error_details))
     slack_message = SlackMessage(
-        success=len(error_details) == 0,
-        filecount=files_analyzed,
-        recordcount=records_analyzed,
-        validationcount=validation_count,
-        errorcount=validations_failed,
-        errorstring="```%s```" % yaml.dump(
-            error_details, default_flow_style=False),
+        success= total_validations_failed == 0,
+        validation_count=total_validation_count,
+        result_dict=result_dict,
+        err_details=error_details,
         function_name=context.function_name,
         aws_request_id=context.aws_request_id,
         log_group_name=context.log_group_name,

--- a/slacker.py
+++ b/slacker.py
@@ -1,29 +1,66 @@
 from botocore.vendored import requests
 import json
-
+import yaml
 
 class SlackMessage():
-    def __init__(self, success, filecount, recordcount, validationcount, errorcount, errorstring, function_name, aws_request_id, log_group_name, log_stream_name):
-        if success and validationcount > 0:
+    def __init__(self, success, validation_count, result_dict, err_details, function_name, aws_request_id, log_group_name, log_stream_name):
+        if success and validation_count > 0:
             self.validation = "PASSED"
-        elif success and validationcount == 0:
-            self.validation = "N/A"
+        elif success and validation_count == 0:
+            self.validation = "NO RECORDS"
         else:
             self.validation = "FAILED"
-        self.filecount = filecount
-        self.errorstring = "*Failed Validations:* %s" % errorstring
-        if len(self.errorstring) > 2947:
-            self.errorstring = self.errorstring[:2947] + \
-                " ... [TRUNCATED LIST]```"
-        self.recordcount = recordcount
-        self.validationcount = validationcount
-        self.errorcount = errorcount
+        self.result_dict = result_dict
+        self.err_details = err_details
         self.function_name = function_name
         self.aws_request_id = aws_request_id
         self.log_group_name = log_group_name
         self.log_stream_name = log_stream_name
 
     def send(self, logger, dest_url, extra_message=None):
+        result_blocks = []
+        for data_provider, dpdict in self.result_dict.items():
+            result_blocks.append({
+                'type': 'section',
+                'text': {
+                    'type': 'mrkdwn',
+                    'text': '*Data Provider - {}*'.format(data_provider.upper())
+                }
+            })
+            for message_type, result in dpdict.items():
+                # Add count details
+                result_blocks.append({
+                    'type': 'section',
+                    'text': {
+                        'type': 'mrkdwn',
+                        'text': (
+                            '*{} messages*\n'.format(message_type.upper())+
+                            '* {} records from {} files analyzed\n'.format(result['records_analyzed'], result['files_analyzed'])+
+                            '* {}/{} validations failed ({}%)\n'.format(result['validations_failed'], result['validation_count'], result['validations_failed']*100/result['validation_count'])
+                        )
+                    }
+                })
+                # Add error information
+                if result['validations_failed'] > 0:
+                    errKey = data_provider+','+message_type
+                    errors = yaml.dump(self.err_details[errKey], default_flow_style=False)
+                    if errors:
+                        groupErrors = "```%s```" % errors
+                    if len(groupErrors) > 2947:
+                        groupErrors = groupErrors[:2947] + " ... [TRUNCATED LIST]```"
+                    result_blocks.append({
+                                        "type": "section",
+                                        "text": {
+                                                "type": "mrkdwn",
+                                                "text": "*Error Details*\n"+groupErrors
+                                        }
+                                    },)
+            result_blocks.append({'type': 'divider'})
+
+        alert_tags = ""
+        if self.validation != "PASSED":
+            alert_tags = "<@WAZT6U66R>"
+
         slack_message = {
             "blocks": [
                 {
@@ -32,38 +69,14 @@ class SlackMessage():
                 {
                     "type": "section",
                     "text": {
-                            "type": "mrkdwn",
-                        "text": "*Validation Result:* %s" % self.validation
+                        "type": "mrkdwn",
+                        "text": "*=== Daily CVP Sandbox Ingestion Report ===*\n {}\n {}".format(self.validation, alert_tags)
                     }
                 },
                 {
-                    "type": "section",
-                    "text": {
-                            "type": "mrkdwn",
-                        "text": "*Files Analyzed:* %d" % self.filecount
-                    }
+                    "type": "divider"
                 },
-                {
-                    "type": "section",
-                    "text": {
-                            "type": "mrkdwn",
-                        "text": "*Records Analyzed:* %d" % self.recordcount
-                    }
-                },
-                {
-                    "type": "section",
-                    "text": {
-                            "type": "mrkdwn",
-                        "text": "*Validations Performed:* %d" % self.validationcount
-                    }
-                },
-                {
-                    "type": "section",
-                    "text": {
-                            "type": "mrkdwn",
-                        "text": "*Validations Failed:* %d" % self.errorcount
-                    }
-                },
+            ]+result_blocks+[
                 {
                     "type": "section",
                     "text": {
@@ -84,28 +97,18 @@ class SlackMessage():
                             "type": "mrkdwn",
                         "text": "*CloudWatch Logs:* %s" % "https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEventViewer:group="+self.log_group_name+";stream="+self.log_stream_name
                     }
-                },
-                {
-                    "type": "divider"
                 }
             ]
         }
-        if self.errorcount > 0:
-                slack_message['blocks'].insert(6, {
-                    "type": "section",
-                    "text": {
-                        "type": "mrkdwn",
-                                "text": self.errorstring
-                    }
-                })
         if extra_message:
-                slack_message['blocks'].insert(7, {
-                    "type": "section",
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": "*Additional Information:* %s" % extra_message
-                    }
-                })
+            slack_message['blocks'].append({
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "*Additional Information:* %s" % extra_message
+                }
+            })
+        slack_message['blocks'].append({"type": "divider"})
         logger.info("Sending slack message to %s" % dest_url)
         logger.debug(json.dumps(slack_message))
         with requests.Session() as session:


### PR DESCRIPTION
Update daily ingestion slack message to group file/record/validation/error counts by Data Provider and by Message type. Slack message will also @ mention users when there has been errors or when there has been no records.